### PR TITLE
feat: config provider

### DIFF
--- a/providers/base.py
+++ b/providers/base.py
@@ -4,10 +4,28 @@ from bs4 import BeautifulSoup
 from abc import ABC, abstractmethod
 from logger import setup_logger
 from models.story_info import StoryInfo
+from utils.config import get_config
 
 logger = setup_logger()
 
 class BaseProvider(ABC):
+    @abstractmethod
+    def __init__(self, id: str, last_chapter: int = 0):
+        """
+            Initializes the BaseProvider instance.
+
+            Args:
+                id (str): The unique identifier for the provider.
+                last_chapter (int, optional): The last chapter number. Defaults to 0.
+        """
+        name = getattr(self, "name", None)
+        if name is not None:
+            self.config = get_config(f"provider.{name}")
+        else:
+            self.config = None
+        self.id = id
+        self.last_chapter = last_chapter
+
     @staticmethod
     def parse_html(html_content: str) -> BeautifulSoup:
         """
@@ -47,18 +65,6 @@ class BaseProvider(ABC):
         except requests.RequestException as e:
             logger.error(f"GET {url} failed: {e}")
             return None
-
-    @abstractmethod
-    def __init__(self, id: str, last_chapter: int = 0):
-        """
-            Initializes the BaseProvider instance.
-
-            Args:
-                id (str): The unique identifier for the provider.
-                last_chapter (int, optional): The last chapter number. Defaults to 0.
-        """
-        self.id = id
-        self.last_chapter = last_chapter
 
     @abstractmethod
     def get_story_info(self) -> StoryInfo:

--- a/providers/goctruyentranhvui.py
+++ b/providers/goctruyentranhvui.py
@@ -1,4 +1,6 @@
 from typing import Optional
+
+from utils.config import get_config
 from .base import BaseProvider
 from consts import ProviderName
 from consts.enpoint import ENDPOINTS
@@ -14,6 +16,7 @@ class GocTruyenTranhVuiProvider(BaseProvider):
                 id (str): The unique identifier for the provider.
                 last_chapter (int, optional): The last chapter number. Defaults to 0.
         """
+        self.name = ProviderName.GOCTRUYENTRANHVUI.value
         super().__init__(id, last_chapter)
 
     def fetch_html(self) -> Optional[str]:
@@ -31,11 +34,10 @@ class GocTruyenTranhVuiProvider(BaseProvider):
 
         url = f"{ENDPOINTS[ProviderName.GOCTRUYENTRANHVUI]}/{self.id}"
         headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            "User-Agent": self.config['user_agent']
         }
-
         cookies = {
-            "cf_clearance": "s_ZvT2HcGjkBAgdyEQHQwccW8JWn97taw2tjrKpCfKs-1753234316-1.2.1.1-xYdxH_pQzk9epeTe6XkMWcR0XdzySEp7iDfJ326_jjRjwTC3UGKGSy.agsXQTF1jTOyTl1pIiygrbSoMVM0E1idyBQgQ2WgVztxYorXQJ7xCyRTpH8k24fM4jT681okzSNppBAVbkI3AZgGbxfBW9YZSrZ0ZhtRaYLfro8VSY4P_hEtwERep4o.n5Ztmbaouvrj1DJ01GnmaHOxYftMo3Ylkz4YLzyBzupIbp8c6RZe7p2Lxh9uc0kU7J5fVu_jq"
+            "cf_clearance": self.config['cf_clearance']
         }
         res = super().request_get(url, headers=headers, cookies=cookies)
         return res.text if res else None


### PR DESCRIPTION
```toml
[provider.goctruyentranhvui]
user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 Edg/138.0.0.0"
cf_clearance = "JytKlp32_XWuxYQ1OY0kArT9yn7j2OVhewF59zEfkL8"
```

config example